### PR TITLE
Proof of concept for running command in visual mode

### DIFF
--- a/lua/whop/init.lua
+++ b/lua/whop/init.lua
@@ -44,7 +44,13 @@ end
 
 --- Runs a selected command
 --- @param cmd string: command to run
-whop.run_cmd = function(cmd)
+--- @param mode string: current mode (n or v)
+whop.run_cmd = function(cmd, mode)
+  if mode == "v" then
+    local range_cmd = cmd:gsub("%%", "'<,'>")
+    vim.cmd(range_cmd)
+    return
+  end
   if type(cmd) == "function" then
     cmd()
   elseif type(cmd) == "string" then
@@ -62,21 +68,25 @@ whop.select = function()
       return item
     end,
   }, function(choice)
-    whop.find_and_run_cmd(choice)
+    local cmd = whop.find_cmd(choice)
+    if cmd == nil then
+      return
+    end
+    whop.run_cmd(cmd.cmd, "n")
   end)
 end
 
 --- Find a command by name and run it.
 --- Do nothing if the command was not found.
 --- @param name string: the name of the command to run
-whop.find_and_run_cmd = function(name)
+whop.find_cmd = function(name)
   for _, v in ipairs(whop._commands) do
     if v.name == name then
-      whop.run_cmd(v.cmd)
-      return true
+      return v
     end
   end
-  return false
+  print("Command not found")
+  return nil
 end
 
 return whop

--- a/plugin/whop.lua
+++ b/plugin/whop.lua
@@ -1,11 +1,21 @@
 vim.api.nvim_create_user_command("Whop", function(arg)
+  -- print(arg.mode)
+  local mode = "n"
+  if arg.range ~= 0 then
+    mode = "v"
+  end
   local whop = require("whop")
   if arg.args ~= "" then
-    whop.find_and_run_cmd(arg.args)
+    local cmd = whop.find_cmd(arg.args)
+    if cmd == nil then
+      return
+    end
+    whop.run_cmd(cmd.cmd, mode)
     return
   end
-  whop.select()
+  whop.select(mode)
 end, {
+  range = true,
   nargs = "?",
   complete = function()
     local whop = require("whop")


### PR DESCRIPTION
This is a proof of concept to resolve #1.

- It is not so pretty, but it works on multiple lines with `:Whop` command
- It doesn't work on a range inside one line
- It doesn't work after selecting a command via vim.ui.select and Telescope

And there is also a caveat that currently commands are define with `%` prefix, which has to be substituted with `<,'>`, that's why I am thinking about changing the API to make `%` in the beginning of the text command optional.

Please leave a comment what do you think about this POC, thank you.